### PR TITLE
Export as PrismLang.HTML, following support from @zeplin/cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 
 # Editor
 .vscode/
+
+# For local testing w/ `npm pack`
+*.tgz

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,14 +12,7 @@ export default class implements ConnectPlugin {
     }
 
     async process(context: ComponentConfig): Promise<ComponentData> {
-       /** 
-        * @TODO Determine if we can switch to `PrismLang.HTML`
-        * Vue templates have no perfect analog in Prism-supported languages,
-        * though they're more similar to HTML than JSX. 
-        * For now, `PrismLang.Markup` is a great solution;
-        * see https://github.com/zeplin/connected-components-beta-issues/issues/4#issuecomment-562738427
-        */
-       const lang = PrismLang.Markup
+       const lang = PrismLang.HTML
        
        const componentInfo = await parse(context.path)
        


### PR DESCRIPTION
Fixes #1 